### PR TITLE
☸  dev 환경 wafflestudio-cluster 에 자동 배포 설정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,7 +14,6 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}
       ECR_REGISTRY: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com
       ECR_REPOSITORY: snutt-dev/snutt-ev-web
-      S3_BUCKET_NAME: snutt-ev-web-build
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,10 +10,10 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: latest-dev
+      IMAGE_TAG: ${{ github.run_number }}
       BUILD_NUMBER: ${{ github.run_number }}
       ECR_REGISTRY: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com
-      ECR_REPOSITORY: snutt/snutt-ev-web
+      ECR_REPOSITORY: snutt-dev/snutt-ev-web
       S3_BUCKET_NAME: snutt-ev-web-build
 
     steps:
@@ -27,12 +27,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload Dockerrun.aws.json to S3
-        run: |
-          mv Dockerrun-dev.aws.json Dockerrun.aws.json
-          zip deploy-dev.zip Dockerrun.aws.json
-          aws s3 cp deploy-dev.zip s3://$S3_BUCKET_NAME/deploy-dev.zip
-
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -43,19 +37,3 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg APP_ENV=dev .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-      - name: Delete untagged images in ECR
-        run: |
-          UNTAGGED_IMAGES=$( aws ecr list-images --repository-name $ECR_REPOSITORY --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
-          aws ecr batch-delete-image --repository-name $ECR_REPOSITORY --image-ids "$UNTAGGED_IMAGES" || true
-
-      - name: Deploy to ElasticBeanstalk
-        run: |
-          aws elasticbeanstalk create-application-version \
-            --application-name snutt-ev-web \
-            --version-label dev-$BUILD_NUMBER \
-            --description dev-$BUILD_NUMBER \
-            --source-bundle S3Bucket=$S3_BUCKET_NAME,S3Key='deploy-dev.zip'
-          aws elasticbeanstalk update-environment \
-            --environment-name snutt-ev-web-dev \
-            --version-label dev-$BUILD_NUMBER


### PR DESCRIPTION
wafflestudio/snutt-ev#60, wafflestudio/snutt#224 와 같은 변경.

[ecr-image-tag-updater](https://github.com/wafflestudio/ecr-image-tag-updater)를 이용해 wafflestudio-cluster 에 자동 배포

### how it works
1. GitHub Actions (in each repo) build and push docker image to ECR
2. ECR push event triggers AWS Lambda function
3. This Lambda function updates the image tag of the corresponding manifest file in [waffle-world](https://github.com/wafflestudio/waffle-world)
4. ArgoCD detects the change in the manifest file and deploys the new image

(ECR 에 untagged image 삭제하는 건, ECR 자체 lifecycle policy 설정으로 5개 초과해서 이미지 저장되면 오래된 것부터 지우게 설정해두어서 스크립트로 처리할 필요가 없어짐)
