### PR TITLE
:alien: Modify dev ev-server url of  server-side

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,7 +1,7 @@
 SERVER_SIDE_CORE_API_URL=https://snutt-api-dev.wafflestudio.com
 NEXT_PUBLIC_CORE_API_URL=https://snutt-api-dev.wafflestudio.com
 
-SERVER_SIDE_EV_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service
+SERVER_SIDE_EV_API_URL=http://snutt-ev.snutt-dev.svc.cluster.local
 NEXT_PUBLIC_EV_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service
 
 NEXT_PUBLIC_APP_ENV=dev


### PR DESCRIPTION
dev 환경은 server side 가 k8s cluster 에 존재하기에, 굳이 VPC 밖으로 나가지 않고 같이 cluster 내에 있는 snutt-ev 로 바로 요청 보내도록 변경