### PR TITLE
✨  강의평 공감 기능 (2): 강의평 좋아요 api 쏘는 기능 구현

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const PORT = 3001;
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e',
-  timeout: 30 * 1000,
+  timeout: 10 * 1000,
 
   expect: { timeout: 5000 },
 

--- a/src/lib/apis/ev/index.ts
+++ b/src/lib/apis/ev/index.ts
@@ -139,3 +139,19 @@ export async function listMyEvaluations(args: Args<undefined, { cursor?: string 
   const response = await evClient.get<ListMyEvaluationsResponse>(endpoint, { headers, params: query });
   return response.data;
 }
+
+export async function likeEvaluation(args: Args<{ id: number }>) {
+  const endpoint = `/v1/evaluations/${args.params.id}/likes`;
+  const headers = getServerSideHeaders(args.context);
+
+  const response = await evClient.post<never>(endpoint, { headers });
+  return response.data;
+}
+
+export async function unlikeEvaluation(args: Args<{ id: number }>) {
+  const endpoint = `/v1/evaluations/${args.params.id}/likes`;
+  const headers = getServerSideHeaders(args.context);
+
+  const response = await evClient.delete<never>(endpoint, { headers });
+  return response.data;
+}

--- a/src/mocks/handlers/ev/index.ts
+++ b/src/mocks/handlers/ev/index.ts
@@ -116,4 +116,12 @@ export const evHandlers = [
     const paginatedResult = getPaginatedResult(mockLectureEvaluations, req.url.searchParams.get('cursor') ?? undefined);
     return res(ctx.json(paginatedResult));
   }),
+
+  rest.post<never, never>(`*/v1/evaluations/:id/likes`, (req, res, ctx) => {
+    return res(ctx.delay(300), ctx.status(200));
+  }),
+
+  rest.delete<never, never>(`*/v1/evaluations/:id/likes`, (req, res, ctx) => {
+    return res(ctx.delay(300), ctx.status(200));
+  }),
 ];

--- a/src/pageImpl/detailImpl/index.tsx
+++ b/src/pageImpl/detailImpl/index.tsx
@@ -115,6 +115,7 @@ export const DetailImpl = () => {
             <ReviewList>
               {myLectureEvaluations?.map((content) => (
                 <LectureReviewCard
+                  lectureId={lectureId}
                   review={content}
                   key={content.id}
                   onMoreClick={() => setMoreSheetItemId(content.id)}
@@ -125,6 +126,7 @@ export const DetailImpl = () => {
               <>
                 {lectureEvaluations?.map((it) => (
                   <LectureReviewCard
+                    lectureId={lectureId}
                     review={it}
                     key={it.id}
                     onMoreClick={() => setMoreSheetItemId(it.id)}

--- a/src/pageImpl/mainImpl/index.tsx
+++ b/src/pageImpl/mainImpl/index.tsx
@@ -74,7 +74,7 @@ export const MainImpl = () => {
             {searchResult?.pages?.map((content, i) => (
               <Fragment key={i}>
                 {content.content.map((it) => (
-                  <EvaluationCard evaluation={it} key={it.id} />
+                  <EvaluationCard evaluation={it} key={it.id} selectedTagId={selectedTagId} />
                 ))}
               </Fragment>
             ))}


### PR DESCRIPTION
강의평 좋아요 api를 실제로 쏘는 기능입니다.

테스트코드를 어떻게 짜야 할지 고민했는데, post request 쏘고 refetch get request 쏘고 invalidate api 쏘는 거 정도만 테스팅하면 되겠죠..? playwright 에서 테스트 러닝 중에 쿠키를 건드릴 수가 없다 보니 msw 에서 쏜 결과가 반영되는 것까지 테스트하는 건 불가능할 것 같긴 한데 아이디어 있으시면 도와주시면 매우 감사드리겠습니다!

---

### ChangeLog

- 강의평 좋아요 / 좋아요 취소 api 추가 및 클릭 시 api 쏘는 기능 구현
- 좋아요 눌렀을 때 request 랑 response 테스트하는 테스트코드 추가
- 강의평 테스트코드 파일 TC에서 좋아요 기능 테스트하는 step 을 따로 분리
- playwright 에 `wait` 하는 케이스가 추가되었는데, 이게 config 에서 30초로 걸려 있어서 30초동안 기다려보고 안오면 터트림. 다시 말해서 10번 실패하면 5분동안 테스트 fail 하는 거 붙들고 있는 건가? 싶어서.. 30초 -> 10초 로 줄였습니다 (사실 5초로 줄여도 될듯)