### PR TITLE
♻️ mui TextField 의존성 제거

### DIFF
--- a/src/lib/components/atoms/Input.tsx
+++ b/src/lib/components/atoms/Input.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import { forwardRef, InputHTMLAttributes } from 'react';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  variant?: 'standard';
+}
+
+export const Input = forwardRef<HTMLInputElement, Props>(({ variant = 'standard', ...props }, ref) => {
+  if (variant === 'standard') return <Standard {...props} ref={ref} />;
+
+  return null;
+});
+
+const Standard = styled.input`
+  background-color: transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+
+  padding: 4px 0 5px;
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+
+  color: ${({ theme }) => theme.colors.text.form};
+  border-bottom-color: ${({ theme }) => theme.colors.bg.divider};
+
+  &:focus {
+    border-bottom-color: ${({ theme }) => theme.colors.border.divider};
+  }
+`;

--- a/src/pageImpl/detailImpl/__components__/ReportEvaluationDialog.tsx
+++ b/src/pageImpl/detailImpl/__components__/ReportEvaluationDialog.tsx
@@ -1,9 +1,10 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { useState } from 'react';
 
 import { Button } from '@/lib/components/atoms/Button';
+import { Input } from '@/lib/components/atoms/Input';
 
 interface Props {
   isOpen: boolean;
@@ -27,15 +28,7 @@ export const ReportEvaluationDialog = ({ isOpen, close, report }: Props) => {
       <Title>강의평 신고</Title>
       <DialogContent>
         <ContentText>강의평 신고 사유를 적어주세요.</ContentText>
-        <TextField
-          sx={{ input: { color: theme.colors.text.form } }}
-          autoFocus
-          margin="dense"
-          fullWidth
-          variant="standard"
-          value={reason}
-          onChange={(e) => setReason(e.target.value)}
-        />
+        <StyledInput variant="standard" value={reason} onChange={(e) => setReason(e.target.value)} />
       </DialogContent>
       <DialogActions>
         <Button variant="text" size="small" onClick={handleClose}>
@@ -55,4 +48,9 @@ const Title = styled(DialogTitle)`
 
 const ContentText = styled(DialogContentText)`
   color: ${({ theme }) => theme.colors.text.default};
+`;
+
+const StyledInput = styled(Input)`
+  margin-top: 16px;
+  width: 100%;
 `;


### PR DESCRIPTION
번들 사이즈 16~17kb 감소

- 기존

![image](https://user-images.githubusercontent.com/39977696/204101702-d652bd0a-c752-4b20-82f6-871312d29e12.png)

- 개선 이후

![image](https://user-images.githubusercontent.com/39977696/204118222-d1edbf50-c544-4838-9323-8b75cf338582.png)


- [kanban](https://www.notion.so/wafflestudio/mui-TextField-359c17a8880c4a1d9ecb19b4902edb20)
