### PR TITLE
♻️ mui Slider 의존성 제거

### DIFF
--- a/src/lib/components/RatingGraph/index.tsx
+++ b/src/lib/components/RatingGraph/index.tsx
@@ -1,27 +1,27 @@
 interface Props {
-  gradeSatisfaction: number; // int 1~5
-  lifeBalance: number; // int 1~5
-  gains: number; // int 1~5
-  teachingSkill: number; // int 1~5
+  top: number; // int 1~5
+  right: number; // int 1~5
+  bottom: number; // int 1~5
+  left: number; // int 1~5
   height: number;
   width: number;
 }
 
-export const RatingGraph = ({ gradeSatisfaction, lifeBalance, gains, teachingSkill, height, width }: Props) => {
+export const RatingGraph = ({ top, right, bottom, left, height, width }: Props) => {
   const xMid = width / 2;
   const yMid = height / 2;
 
-  const gradeSatisfactionY = yMid - gradeSatisfaction * (yMid / 5);
-  const lifeBalanceX = xMid + lifeBalance * (xMid / 5);
-  const gainsY = yMid + gains * (yMid / 5);
-  const teachingSkillX = xMid - teachingSkill * (xMid / 5);
+  const topY = yMid - top * (yMid / 5);
+  const rightX = xMid + right * (xMid / 5);
+  const bottomY = yMid + bottom * (yMid / 5);
+  const leftX = xMid - left * (xMid / 5);
 
   return (
     <svg width={width} height={height} viewBox={`0 0 ${height} ${width}`} fill="none">
       <path d={`M 0 ${yMid} L ${width} ${yMid}`} stroke="rgb(194, 194, 194)" />
       <path d={`M ${xMid} 0 L ${xMid} ${height}`} stroke="rgb(194, 194, 194)" />
       <path
-        d={`M ${teachingSkillX} ${yMid} L ${xMid} ${gradeSatisfactionY} L ${lifeBalanceX} ${yMid} L ${xMid} ${gainsY} L ${teachingSkillX} ${yMid} Z`}
+        d={`M ${leftX} ${yMid} L ${xMid} ${topY} L ${rightX} ${yMid} L ${xMid} ${bottomY} L ${leftX} ${yMid} Z`}
         fill="#1BD0C8"
         fillOpacity="0.4"
         stroke="#1BD0C8"

--- a/src/pageImpl/createImpl/__components__/EvalPolygon.tsx
+++ b/src/pageImpl/createImpl/__components__/EvalPolygon.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
-import { Slider } from '@mui/material';
 
 import { RatingGraph } from '@/lib/components/RatingGraph';
 import { DetailHighlight, Title01 } from '@/lib/components/Text';
 import { RatingTooltip } from '@/lib/components/Tooltip';
+import { COLORS } from '@/lib/styles/colors';
 
 interface Props {
-  defaultValue: number;
   score: {
     top: number;
     left: number;
@@ -16,16 +15,8 @@ interface Props {
   handleUpdateScore: (value: number, direction: 'top' | 'left' | 'bottom' | 'right') => void;
 }
 
-export const EvalPolygon = ({ defaultValue, score, handleUpdateScore }: Props) => {
+export const EvalPolygon = ({ score, handleUpdateScore }: Props) => {
   const { top, left, bottom, right } = score;
-
-  const sliderCommonProps = {
-    min: 0,
-    max: 5,
-    step: 1,
-    defaultValue,
-    valueLabelDisplay: 'off' as const,
-  };
 
   return (
     <Container>
@@ -33,6 +24,7 @@ export const EvalPolygon = ({ defaultValue, score, handleUpdateScore }: Props) =
         <Title01>점을 움직여 네가지 항목을 평가해주세요</Title01>
         <RatingTooltip />
       </Row>
+
       <GraphWrapper>
         <RatingGraph
           gradeSatisfaction={top}
@@ -42,45 +34,29 @@ export const EvalPolygon = ({ defaultValue, score, handleUpdateScore }: Props) =
           height={300}
           width={300}
         />
+
         <AxisLabel>
           <YAxisPositive>성적 만족도</YAxisPositive>
           <YAxisNegative>얻어가는 것</YAxisNegative>
           <XAxisNegative>강의력</XAxisNegative>
           <XAxisPositive>수라밸</XAxisPositive>
         </AxisLabel>
-        <CustomSliderRight
-          value={right}
-          onChange={withChangeSlider((newValue) => handleUpdateScore(newValue, 'right'))}
-          {...sliderCommonProps}
-        />
-        <CustomSliderTop
-          value={top}
-          onChange={withChangeSlider((newValue) => handleUpdateScore(newValue as number, 'top'))}
-          orientation={'vertical'}
-          {...sliderCommonProps}
-        />
-        <CustomSliderLeft
-          dir="rtl"
-          value={5 - left}
-          onChange={withChangeSlider((newValue) => handleUpdateScore(5 - (newValue as number), 'left'))}
-          {...sliderCommonProps}
-        />
-        <CustomSliderBottom
-          value={5 - bottom}
-          onChange={withChangeSlider((newValue) => handleUpdateScore(5 - (newValue as number), 'bottom'))}
-          orientation={'vertical'}
-          {...sliderCommonProps}
-        />
+
+        {(['top', 'left', 'right', 'bottom'] as const).map((d) => (
+          <ScoreSlider
+            key={d}
+            $direction={d}
+            type="range"
+            min={0}
+            max={5}
+            step={1}
+            value={score[d]}
+            onChange={(e) => handleUpdateScore(Number(e.target.value), d)}
+          />
+        ))}
       </GraphWrapper>
     </Container>
   );
-};
-
-const withChangeSlider = (callback: (newValue: number) => void) => {
-  return (e: unknown, newValue: number | number[]) => {
-    if (Array.isArray(newValue)) return;
-    callback(newValue);
-  };
 };
 
 const Container = styled.div`
@@ -106,74 +82,44 @@ const GraphWrapper = styled.div`
   margin-top: 72px;
 `;
 
-const CustomSlider = styled(Slider)`
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
+const ScoreSlider = styled.input<{ $direction: keyof Props['score'] }>`
+  position: absolute;
+  width: calc(50% + 18px);
+  height: 0px;
+  top: 50%;
+  left: 50%;
+  transform-origin: left;
+  transform: rotate(${({ $direction }) => ({ top: 270, left: 180, bottom: 90, right: 0 }[$direction])}deg)
+    translateY(-50%);
 
-  .MuiSlider-rail {
-    display: none;
+  margin: 0;
+  -webkit-appearance: none; /* Override default CSS styles */
+  appearance: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
   }
 
-  .MuiSlider-track {
-    display: none;
-  }
-
-  .MuiSlider-thumb {
+  &::-webkit-slider-thumb {
+    cursor: pointer;
+    transform: translateX(-9px);
     width: 18px;
     height: 18px;
-    box-sizing: border-box;
+    background-color: ${COLORS.white};
     border-radius: 50%;
-    border: 2px solid #1ac5bd;
-    background-color: #fff;
-    transition: none;
-
-    // important 안주면 Mui default css 우선순위가 더 높음
-    box-shadow: none !important;
-
-    &::after {
-      content: none;
-    }
+    border: 2px solid ${COLORS.mint};
   }
-`;
 
-const CustomSliderVertical = styled(CustomSlider)`
-  height: 150px;
-  width: 4px;
-  padding: 0px 13px;
-`;
-
-const CustomSliderHorizontal = styled(CustomSlider)`
-  height: 4px;
-  width: 150px;
-  padding: 13px 0;
-`;
-
-const CustomSliderRight = styled(CustomSliderHorizontal)`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-2px, -50%);
-`;
-
-const CustomSliderLeft = styled(CustomSliderHorizontal)`
-  position: absolute;
-  top: 50%;
-  left: 0%;
-  transform: translate(0, -50%);
-`;
-
-const CustomSliderTop = styled(CustomSliderVertical)`
-  position: absolute;
-  left: 50%;
-  transform: translate(-50%, 0);
-`;
-
-const CustomSliderBottom = styled(CustomSliderVertical)`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, 0);
+  &::-moz-range-thumb {
+    cursor: pointer;
+    transform: translateX(-9px);
+    width: 18px;
+    height: 18px;
+    background-color: ${COLORS.white};
+    border-radius: 50%;
+    border: 2px solid ${COLORS.mint};
+  }
 `;
 
 const AxisLabel = styled.div`

--- a/src/pageImpl/createImpl/__components__/EvalPolygon.tsx
+++ b/src/pageImpl/createImpl/__components__/EvalPolygon.tsx
@@ -16,8 +16,6 @@ interface Props {
 }
 
 export const EvalPolygon = ({ score, handleUpdateScore }: Props) => {
-  const { top, left, bottom, right } = score;
-
   return (
     <Container>
       <Row>
@@ -26,14 +24,7 @@ export const EvalPolygon = ({ score, handleUpdateScore }: Props) => {
       </Row>
 
       <GraphWrapper>
-        <RatingGraph
-          gradeSatisfaction={top}
-          lifeBalance={right}
-          gains={bottom}
-          teachingSkill={left}
-          height={300}
-          width={300}
-        />
+        <RatingGraph height={300} width={300} {...score} />
 
         <AxisLabel>
           <YAxisPositive>성적 만족도</YAxisPositive>

--- a/src/pageImpl/createImpl/__containers__/usePolygon.ts
+++ b/src/pageImpl/createImpl/__containers__/usePolygon.ts
@@ -1,14 +1,11 @@
 import { useState } from 'react';
 
-export function usePolygon() {
-  const defaultValue = 3;
+const defaultValue = 3;
 
-  const [score, setScore] = useState<{
-    top: number;
-    left: number;
-    bottom: number;
-    right: number;
-  }>({
+type Score = { top: number; left: number; bottom: number; right: number };
+
+export function usePolygon() {
+  const [score, setScore] = useState<Score>({
     top: defaultValue,
     left: defaultValue,
     bottom: defaultValue,
@@ -18,15 +15,8 @@ export function usePolygon() {
   const updateScore = (value: number, direction: 'top' | 'left' | 'bottom' | 'right') => {
     const realValue = value;
     const nextValue = realValue < 1 ? 1 : realValue;
-    setScore((prev) => ({
-      ...prev,
-      [direction]: nextValue,
-    }));
+    setScore((prev) => ({ ...prev, [direction]: nextValue }));
   };
 
-  return {
-    defaultValue,
-    score,
-    updateScore,
-  };
+  return { score, updateScore };
 }

--- a/src/pageImpl/createImpl/index.tsx
+++ b/src/pageImpl/createImpl/index.tsx
@@ -37,7 +37,7 @@ export const CreateImpl = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [dialogErrorMessage, setDialogErrorMessage] = useState('');
 
-  const { defaultValue, score, updateScore } = usePolygon();
+  const { score, updateScore } = usePolygon();
 
   const [contentsUnsatisfied, setContentsUnsatisfied] = useState(true);
 
@@ -140,7 +140,7 @@ export const CreateImpl = () => {
   };
 
   const stepComponents = [
-    <EvalPolygon key={1} defaultValue={defaultValue} score={score} handleUpdateScore={updateScore} />,
+    <EvalPolygon key={1} score={score} handleUpdateScore={updateScore} />,
     <EvalBasic
       key={2}
       handleRating={handleRating}

--- a/src/pageImpl/detailImpl/__components__/EvaluationDetailScore.tsx
+++ b/src/pageImpl/detailImpl/__components__/EvaluationDetailScore.tsx
@@ -17,10 +17,10 @@ export const EvaluationDetailScore = ({ score, isSnuevWarning = false, size = 28
           <RatingGraphAxis height={size} width={size} />
         ) : (
           <RatingGraph
-            gradeSatisfaction={score.grade_satisfaction ?? 0}
-            lifeBalance={score.life_balance ?? 0}
-            gains={score.gains ?? 0}
-            teachingSkill={score.teaching_skill ?? 0}
+            top={score.grade_satisfaction ?? 0}
+            right={score.life_balance ?? 0}
+            bottom={score.gains ?? 0}
+            left={score.teaching_skill ?? 0}
             height={size}
             width={size}
           />


### PR DESCRIPTION
## Summary

mui slider 대신 input type=range 이용합니다. 7kb 정도 줄였습니다.

## Description

기존

![image](https://user-images.githubusercontent.com/39977696/204118923-a7c9a1d4-8213-400f-92dd-14d9cd008a3c.png)

개선 이후

![image](https://user-images.githubusercontent.com/39977696/204120187-481fdeab-5eba-47fd-a877-1c4c142bc916.png)

## Screenshots

## Focus

## References

- [kanban](https://www.notion.so/wafflestudio/mui-Slider-9857a4bacf2d4bdda29ee02bac9beb04)
