### PR TITLE
🩹 태그 줄바꿈될 때 스타일 깨지는 이슈 픽스

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.24.0-sdk",
+  "version": "8.28.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "2.7.1-sdk",
+  "version": "2.8.0-sdk",
   "main": "./index.js",
   "type": "commonjs"
 }

--- a/src/mocks/handlers/ev/fixtures.ts
+++ b/src/mocks/handlers/ev/fixtures.ts
@@ -87,6 +87,16 @@ export const mockMainTags = {
   tags: [
     { id: 1, name: '최신', description: '최근 등록된 강의평', ordering: 1 },
     { id: 2, name: '추천', description: '학우들의 추천 강의', ordering: 2 },
+    { id: 3, name: '테스트1', description: '학우들의 추천 강의', ordering: 3 },
+    {
+      id: 4,
+      name: '테스트2',
+      description:
+        '학우들의 추천 강의학우들의 추천 강의학우들의 추천 강의학우들의 추천 강의학우들의 추천 강의학우들의 추천 강의학우들의 추천 강의',
+      ordering: 4,
+    },
+    { id: 5, name: '테스트3', description: '학우들의 추천 강의', ordering: 5 },
+    { id: 6, name: '테스트4', description: '학우들의 추천 강의', ordering: 6 },
   ],
 };
 

--- a/src/pageImpl/mainImpl/index.tsx
+++ b/src/pageImpl/mainImpl/index.tsx
@@ -48,7 +48,7 @@ export const MainImpl = () => {
             const isSelected = id === selectedTagId;
 
             return (
-              <ToggleChip
+              <Chip
                 value={id}
                 key={id}
                 data-testid="main-category-toggle-chip"
@@ -57,7 +57,7 @@ export const MainImpl = () => {
                 onClick={() => onClickTag(id)}
               >
                 {name}
-              </ToggleChip>
+              </Chip>
             );
           })}
         </ChipsWrapper>
@@ -105,12 +105,9 @@ const CategoryDetail = styled(Subheading02)`
 
 const ChipsWrapper = styled.div`
   padding-top: 6px;
-`;
-
-const ToggleChip = styled(Chip)`
-  &:not(:first-of-type) {
-    margin-left: 10px;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 `;
 
 const CategoryPickerTitleWrapper = styled.div`


### PR DESCRIPTION
fixes https://wafflestudio.slack.com/archives/C0PAVPS5T/p1671368132905159?thread_ts=1671269095.692439&cid=C0PAVPS5T

기존

![image](https://user-images.githubusercontent.com/39977696/208300086-147872a1-b6f4-4f09-a295-5b491d21e587.png)

변경

![image](https://user-images.githubusercontent.com/39977696/208300063-934f40d3-5b37-40da-974b-b6a79ab7b87f.png)

[caniuse gap?](https://caniuse.com/?search=gap)