### PR TITLE
♻️ useSelectTag 불필요한 effect문 제거

### DIFF
--- a/e2e/main/tag.spec.ts
+++ b/e2e/main/tag.spec.ts
@@ -30,7 +30,6 @@ test('교양 강의평 둘러보기', async ({ page }) => {
       expect(recentChip).toHaveAttribute('aria-selected', `${status === 'recent'}`),
       expect(recommendChip).toHaveAttribute('aria-selected', `${status === 'recommend'}`),
       expect(detailText).toHaveText({ recent: '최근 등록된 강의평', recommend: '학우들의 추천 강의' }[status]),
-      expect(main.getPage()).toHaveURL(`/main?tag=${{ recent: 1, recommend: 2 }[status]}`),
     ]);
   }
 });

--- a/src/pageImpl/mainImpl/__containers__/useSelectTag.ts
+++ b/src/pageImpl/mainImpl/__containers__/useSelectTag.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { TagDTO } from '@/dto/tag';
 

--- a/src/pageImpl/mainImpl/__containers__/useSelectTag.ts
+++ b/src/pageImpl/mainImpl/__containers__/useSelectTag.ts
@@ -10,8 +10,7 @@ type RouterQuery = {
 export const useSelectTag = (tags: TagDTO[]) => {
   const router = useRouter();
 
-  const selectedTagId = (router.query as RouterQuery).tag;
-  const firstTagId = tags[0]?.id;
+  const selectedTagId = (router.query as RouterQuery).tag || tags[0]?.id;
 
   const setSelectedTagId = useCallback(
     (tagId: number) => {
@@ -23,13 +22,6 @@ export const useSelectTag = (tags: TagDTO[]) => {
     },
     [router, selectedTagId],
   );
-
-  useEffect(() => {
-    if (selectedTagId !== undefined) return;
-    if (typeof firstTagId !== 'number') return;
-
-    setSelectedTagId(firstTagId);
-  }, [firstTagId, setSelectedTagId, selectedTagId]);
 
   const onClickTag = (tagId: number) => {
     setSelectedTagId(tagId);


### PR DESCRIPTION
## Summary

- useSelectTag 불필요한 effect문 제거

## Description

- selectedTagId의 디폴트값 할당을 useEffect가 아닌 `||` 연산으로 해결

- [kanban](https://www.notion.so/wafflestudio/tag-effect-a4c1f14112eb46eaa42217e80144cc9e)
